### PR TITLE
Mismatching allocation-deallocation

### DIFF
--- a/libfovis/pyramid_level.cpp
+++ b/libfovis/pyramid_level.cpp
@@ -78,7 +78,7 @@ PyramidLevel::~PyramidLevel()
   free(_raw_gray);
   free(_descriptors);
   free(_pyrbuf);
-  free(_keypoints);
+  delete[] _keypoints;
   delete _descriptor_extractor;
   _raw_gray = NULL;
   _descriptors = NULL;


### PR DESCRIPTION
Uses delete[] instead of free() to remove cppcheck error regarding mismatching allocation-deallocation.
